### PR TITLE
fix for the pip-installed standardiser exe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     license='Apache License, Version 2.0',
     entry_points={
         'console_scripts': [
-            'standardiser=standardiser.bin.standardiser:main']},
+            'standardiser=standardiser.bin.standardise_mols:main']},
     packages=['standardiser',
               'standardiser.bin'],
     long_description=open('ReadMe.txt').read(),


### PR DESCRIPTION
I patched the pip-installed script in this way.
I don't know how to check if this is the proper fix for the pip package.
I just guess this is the way to fix it.
